### PR TITLE
Improved Windows support

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,6 +2,7 @@
 'use strict';
 
 const fs = require('fs-extra');
+const os = require('os');
 const path = require('path');
 const findUp = require('find-up');
 const promisify = require('typeable-promisify');
@@ -9,7 +10,7 @@ const onExit = require('signal-exit');
 const rimraf = require('rimraf');
 
 const slice = Array.prototype.slice;
-const TEMP_PATH = path.join('/tmp', 'jest-fixture-');
+const TEMP_PATH = path.join(os.tmpdir(), 'jest-fixture-');
 const TEMP_DIRS_CREATED = [];
 
 function toFixturesDir(fileParts) {

--- a/test.js
+++ b/test.js
@@ -3,6 +3,7 @@
 
 const fixtures = require('./');
 const fs = require('fs');
+const os = require('os');
 const path = require('path');
 
 const FIXTURES_DIR = path.join(__dirname, 'fixtures');
@@ -51,9 +52,9 @@ describe('getFixturePathSync()', () => {
 });
 
 describe('createTempDir', () => {
-  it('should create a directory in /tmp', () => {
+  it('should create a directory in os.tmpdir()', () => {
     return fixtures.createTempDir().then(dirName => {
-      expect(dirName.startsWith('/tmp/jest-fixture-')).toBe(true);
+      expect(dirName.startsWith(path.join(os.tmpdir(), 'jest-fixture-'))).toBe(true);
       let stat = fs.statSync(dirName);
       expect(stat.isDirectory()).toBe(true);
     });
@@ -61,16 +62,16 @@ describe('createTempDir', () => {
 });
 
 describe('createTempDirSync', () => {
-  it('should create a directory in /tmp', () => {
+  it('should create a directory in os.tmpdir()', () => {
     let dirName = fixtures.createTempDirSync();
-    expect(dirName.startsWith('/tmp/jest-fixture-')).toBe(true);
+    expect(dirName.startsWith(path.join(os.tmpdir(), 'jest-fixture-'))).toBe(true);
     let stat = fs.statSync(dirName);
     expect(stat.isDirectory()).toBe(true);
   });
 });
 
 function assertCopiedFiles(tempDir) {
-  expect(fs.lstatSync(path.join(tempDir, 'symlink-to-file')).isSymbolicLink()).toBe(true);
+  if (process.platform !== 'win32') expect(fs.lstatSync(path.join(tempDir, 'symlink-to-file')).isSymbolicLink()).toBe(true);
   expect(fs.lstatSync(path.join(tempDir, 'file.txt')).isFile()).toBe(true);
   expect(fs.lstatSync(path.join(tempDir, 'nested')).isDirectory()).toBe(true);
   expect(fs.lstatSync(path.join(tempDir, 'nested', 'nested-file.txt')).isFile()).toBe(true);


### PR DESCRIPTION
Hi there! I removed the hard-coded "/tmp" directory assumption in favor of `os.tmpdir()` and modified `assertCopiedFiles` to skip the symlink test on Windows. How about it? 😀 